### PR TITLE
add todo list detail page

### DIFF
--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -1,0 +1,161 @@
+import React, { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import styled from "styled-components";
+import { __deleteTodo, __updateTodo } from "../redux/modules/TodosSlice";
+
+const ItemBox = styled.div`
+  width: 16%;
+  padding: 1%;
+  float: left;
+  flex: 0 0 auto;
+  border: 3px solid cornflowerblue;
+  border-radius: 20px;
+`;
+
+const ItemTitle = styled.h2`
+  font-weight: 800;
+`;
+
+const BtnWrapper = styled.div`
+  width: 100%;
+  padding-top: 20px;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const Btn = styled.button`
+  width: 40%;
+  height: 30px;
+  background-color: ${(props) => props.bgColor};
+  border: none;
+  border-radius: 10px;
+  :hover {
+    cursor: pointer;
+  }
+`;
+
+const DeleteBtnWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: end;
+  align-items: center;
+`;
+
+const DeleteBtn = styled.span`
+  width: 30px;
+  height: 30px;
+  line-height: 30px;
+  text-align: center;
+  background-color: red;
+  color: white;
+  border-radius: 15px;
+  :hover {
+    cursor: pointer;
+  }
+`;
+
+function Item({ todo }) {
+  const todos = useSelector((store) => store.todos.todos);
+  const todosID = useSelector((store) => store.todos.todosID);
+  const dispatch = useDispatch();
+  const [isModify, setIsModify] = useState(false);
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const handleUpdateTodoContent = async () => {
+    try {
+      if (!isModify) {
+        return;
+      }
+
+      if (title.length === 0 || content.length === 0) {
+        return;
+      }
+
+      if (title === todo.title && content === todo.content) {
+        alert("변경된 내용이 없습니다.");
+        return;
+      }
+
+      dispatch(
+        __updateTodo({
+          todosID,
+          todos,
+          todo: { ...todo, title, content },
+        })
+      );
+    } finally {
+      setIsModify(!isModify);
+      setTitle("");
+      setContent("");
+    }
+  };
+  const handleChangeTitle = ({ target: { value } }) => {
+    setTitle(value);
+  };
+  const handleChangeContent = ({ target: { value } }) => {
+    setContent(value);
+  };
+
+  const handleUpdateTodoState = () => {
+    dispatch(
+      __updateTodo({
+        todosID,
+        todos,
+        todo: { ...todo, isDone: !todo.isDone },
+      })
+    );
+  };
+
+  const handleDeleteTodo = () => {
+    dispatch(__deleteTodo({ todosID, todos, todoID: todo.id }));
+  };
+  return (
+    <ItemBox>
+      <DeleteBtnWrapper>
+        <DeleteBtn onClick={handleDeleteTodo}>✖</DeleteBtn>
+      </DeleteBtnWrapper>
+      {isModify ? (
+        <>
+          <div>제목</div>
+          <input
+            value={title}
+            onChange={handleChangeTitle}
+            type="text"
+            placeholder={todo.title}
+          />
+          <div>내용</div>
+          <input
+            value={content}
+            onChange={handleChangeContent}
+            type="text"
+            placeholder={todo.content}
+          />
+        </>
+      ) : (
+        <>
+          <ItemTitle>{todo.title}</ItemTitle>
+          {todo.content}
+        </>
+      )}
+      <BtnWrapper>
+        <Btn onClick={handleUpdateTodoContent} bgColor="gray">
+          {isModify
+            ? title.length === 0 || content.length === 0
+              ? "취소"
+              : "수정완료"
+            : "수정하기"}
+        </Btn>
+        <Btn
+          onClick={handleUpdateTodoState}
+          bgColor={todo.isDone ? "tomato" : "cornflowerBlue"}
+        >
+          {todo.isDone ? "취소" : "완료"}
+        </Btn>
+      </BtnWrapper>
+    </ItemBox>
+  );
+}
+
+export default Item;

--- a/src/components/Progressbar.js
+++ b/src/components/Progressbar.js
@@ -1,0 +1,98 @@
+import React from "react";
+import { useSelector } from "react-redux";
+import styled from "styled-components";
+
+const Wrapper = styled.div`
+  width: 100%;
+  padding: 20px 0;
+`;
+
+const ContentWrapper = styled.div`
+  width: 97%;
+  padding-left: 3%;
+  display: flex;
+  flex-direction: row;
+  justify-content: start;
+  align-items: center;
+`;
+
+const ContentTitle = styled.h2`
+  font-weight: 800;
+  padding-bottom: 20px;
+`;
+
+const ProgressBarWrapper = styled.div`
+  position: relative;
+  width: 80%;
+  height: 30px;
+  border: 1px solid black;
+`;
+
+const ProgressBar = styled.div`
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: ${(props) => props.width};
+  height: 30px;
+  background-color: tomato;
+  transition: width 1s;
+`;
+
+const ProgressBarIcon = styled.span`
+  position: absolute;
+  right: -15px;
+  top: -15px;
+  font-size: 40px;
+  transform: rotateY(180deg);
+`;
+
+const StateWrapper = styled.div`
+  width: 18%;
+  font-size: 20px;
+  font-weight: 800;
+  padding-left: 2%;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+`;
+
+const StateIcon = styled.span`
+  font-size: ${(props) => props.fontSize};
+  transition: font-size 1s;
+`;
+
+function Progressbar() {
+  const todos = useSelector((store) => store.todos.todos);
+  const donesCount = todos.filter((v) => v.isDone === true).length;
+  const donesPercentage = (donesCount / todos.length) * 100;
+  return (
+    <Wrapper>
+      <ContentTitle>progress bar</ContentTitle>
+      <ContentWrapper>
+        <ProgressBarWrapper>
+          <ProgressBar width={`${donesPercentage}%`}>
+            <ProgressBarIcon>🏃</ProgressBarIcon>
+          </ProgressBar>
+        </ProgressBarWrapper>
+        <StateWrapper>
+          <StateIcon
+            fontSize={
+              donesPercentage > 50
+                ? donesPercentage === 100
+                  ? "40px"
+                  : "20px"
+                : "16px"
+            }
+          >
+            🔥
+          </StateIcon>
+          <span>
+            {donesCount}/{todos.length}
+          </span>
+        </StateWrapper>
+      </ContentWrapper>
+    </Wrapper>
+  );
+}
+
+export default Progressbar;

--- a/src/components/TodoInput.js
+++ b/src/components/TodoInput.js
@@ -1,0 +1,97 @@
+import React, { useRef, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import styled from "styled-components";
+import { __addTodo } from "../redux/modules/TodosSlice";
+
+const InputWrapper = styled.div`
+  padding: 20px;
+  background-color: #ccc;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const Label = styled.span`
+  margin-right: 10px;
+`;
+
+const Input = styled.input`
+  width: 300px;
+  height: 30px;
+  margin-right: 10px;
+  text-indent: 10px;
+`;
+
+const Btn = styled.button`
+  width: 300px;
+  height: 30px;
+  background-color: cornflowerblue;
+`;
+
+function TodoInput() {
+  const id = Date.now();
+  const todos = useSelector((store) => store.todos.todos);
+  const todosID = useSelector((store) => store.todos.todosID);
+  const [todo, setTodo] = useState({
+    id,
+    title: "",
+    content: "",
+    isDone: false,
+  });
+  const ref = useRef();
+
+  const handleChangeTitle = ({ target: { value } }) => {
+    setTodo({ ...todo, title: value });
+  };
+
+  const handleChangeContent = ({ target: { value } }) => {
+    setTodo({ ...todo, content: value });
+  };
+
+  const dispatch = useDispatch();
+  const addTodo = () => {
+    try {
+      if (todo.title.length === 0 || todo.content.length === 0) {
+        alert("내용을 입력해주세요.");
+        return;
+      }
+
+      dispatch(__addTodo({ todosID, todos, todo }));
+    } finally {
+      setTodo({
+        id,
+        title: "",
+        content: "",
+        isDone: false,
+      });
+
+      ref.current.focus();
+    }
+  };
+
+  return (
+    <InputWrapper>
+      <div>
+        <Label>제목</Label>
+        <Input
+          ref={ref}
+          value={todo.title}
+          onChange={handleChangeTitle}
+          type="text"
+          placeholder="내용을 입력해주세요."
+        />
+        <Label>내용</Label>
+        <Input
+          value={todo.content}
+          onChange={handleChangeContent}
+          type="text"
+          placeholder="내용을 입력해주세요."
+        />
+      </div>
+      <Btn onClick={addTodo}>추가하기</Btn>
+    </InputWrapper>
+  );
+}
+
+export default TodoInput;

--- a/src/index.js
+++ b/src/index.js
@@ -2,10 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
+import { Provider } from "react-redux";
+import store from "./redux/config/configStore";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
-  // <React.StrictMode>
-  <App />
-  // </React.StrictMode>
+  <Provider store={store}>
+    <App />
+  </Provider>
 );

--- a/src/redux/modules/TodosSlice.js
+++ b/src/redux/modules/TodosSlice.js
@@ -1,14 +1,91 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import axios from "axios";
 
 const initialState = {
   todos: [],
+  todosID: 0,
 };
+
+export const __getTodos = createAsyncThunk(
+  "getTodos",
+  async (payload, thunkAPI) => {
+    try {
+      const { data } = await axios.get(
+        `http://localhost:3001/todos/${payload}`
+      );
+      thunkAPI.dispatch(getTodos(data));
+    } catch (e) {
+      alert(`getTodoError: ${e}`);
+    }
+  }
+);
+
+export const __addTodo = createAsyncThunk(
+  "addTodo",
+  async (payload, thunkAPI) => {
+    try {
+      await axios.patch(`http://localhost:3001/todos/${payload.todosID}`, {
+        items: [...payload.todos, payload.todo],
+      });
+      thunkAPI.dispatch(addTodo(payload.todo));
+    } catch (e) {
+      alert(`addTodoError: ${e}`);
+    }
+  }
+);
+
+export const __updateTodo = createAsyncThunk(
+  "updateTodo",
+  async (payload, thunkAPI) => {
+    try {
+      const updatedTodos = payload.todos.map((v) => {
+        if (v.id === payload.todo.id) return payload.todo;
+        return v;
+      });
+      await axios.patch(`http://localhost:3001/todos/${payload.todosID}`, {
+        items: updatedTodos,
+      });
+      thunkAPI.dispatch(updateTodo(updatedTodos));
+    } catch (e) {
+      alert(`updateTodoError: ${e}`);
+    }
+  }
+);
+
+export const __deleteTodo = createAsyncThunk(
+  "deleteTodo",
+  async (payload, thunkAPI) => {
+    try {
+      const updatedTodos = payload.todos.filter((v) => v.id !== payload.todoID);
+      await axios.patch(`http://localhost:3001/todos/${payload.todosID}`, {
+        items: updatedTodos,
+      });
+      thunkAPI.dispatch(updateTodo(updatedTodos));
+    } catch (e) {
+      alert(`deleteTodoError: ${e}`);
+    }
+  }
+);
 
 const todosSlice = createSlice({
   name: "todos",
   initialState,
-  reducers: {},
+  reducers: {
+    getTodos: (state, action) => {
+      state.todosID = action.payload.id;
+      state.todos = action.payload.items;
+    },
+    addTodo: (state, action) => {
+      state.todos = [...state.todos, action.payload];
+    },
+    updateTodo: (state, action) => {
+      state.todos = action.payload;
+    },
+    deleteTodo: (state, action) => {
+      state.todos = action.payload;
+    },
+  },
 });
 
-export const { addNumber, minusNumber } = todosSlice.actions;
+export const { getTodos, addTodo, updateTodo, deleteTodo } = todosSlice.actions;
 export default todosSlice.reducer;

--- a/src/shared/Routes.js
+++ b/src/shared/Routes.js
@@ -9,7 +9,7 @@ const Router = () => {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Home />} />
-        <Route path="/todos/:date" element={<TodoList />} />
+        <Route path="/todos/:id" element={<TodoList />} />
       </Routes>
     </BrowserRouter>
   );


### PR DESCRIPTION
# Todo 상세페이지 구현

## 구현 상세
1. `shared/Router.js` 추가 
  a. `Home` 페이지(전체 일자 `todos` 목록 조회 및 추가 페이지)와 `TodoList` 페이지(일자별 `todos` 상세페이지)를 URL로 이동할 수 있는 router를 구현
2. `components` 폴더 생성해서 컴포넌트 분리
  a. `Item`: `todo(=item)` 각각의 정보를 보여주고 `todo`의 내용 수정, `isDone` 수정, 삭제 기능을 관리하는 컴포넌트
  b. `Progressbar` :  `todos` 중에서 `isDone = true`인 `todo`의 개수로 완료한 일의 `%`를 계산해 보여주는 컴포넌트 
  c. `TodoInput`: 새로운 `todo` 제목과 내용을 입력받고 추가 기능을 관리하는 컴포넌트
4. `redux/modules/TodosSlice.js` 수정
  a. `redux toolkit`을 사용해 `thunk`로 비동기 action을 처리할 수 있도록 구현
  b. `todos` 하나에 대한 CRUD 구현
