### PR TITLE
fix ref to work on conditional rendering

### DIFF
--- a/src/pages/TodoList.js
+++ b/src/pages/TodoList.js
@@ -49,18 +49,21 @@ const TodoListBox = styled.div`
 
 function TodoList() {
   const { id } = useParams();
+  const isLoading = useSelector((store) => store.todos.isLoading);
   const todos = useSelector((store) => store.todos.todos);
   const todosID = useSelector((store) => store.todos.todosID);
   const dispatch = useDispatch();
   const scrollRef = useRef(null);
 
   const setScroll = () => {
-    scrollRef.current.scrollLeft += 300 * (todos.length - 1);
+    if (scrollRef.current !== null) {
+      scrollRef.current.scrollLeft += 300 * (todos.length - 1);
+    }
   };
 
   useEffect(() => {
     setScroll();
-  }, [todos, scrollRef]);
+  }, [todos]);
 
   useEffect(() => {
     dispatch(__getTodos(id));
@@ -75,28 +78,28 @@ function TodoList() {
       </Header>
       <Progressbar></Progressbar>
       <TodoInput></TodoInput>
-      {/* {todos.length === 0 ? (
+      {todos.length === 0 ? (
         <InfoBox>새로운 할일을 추가해보세요!</InfoBox>
-      ) : ( */}
-      <>
-        <h1>Working</h1>
-        <TodoListBox ref={scrollRef}>
-          {todos.filter((v) => v.isDone === false).length !== 0
-            ? todos
-                .filter((v) => v.isDone === false)
-                .map((v) => <Item key={v.id} todo={v} />)
-            : "추가된 할일이 없습니다."}
-        </TodoListBox>
-        <h1>Done</h1>
-        <TodoListBox>
-          {todos.filter((v) => v.isDone === true).length !== 0
-            ? todos
-                .filter((v) => v.isDone === true)
-                .map((v) => <Item key={v.id} todo={v} />)
-            : "완료된 일이 없습니다."}
-        </TodoListBox>
-      </>
-      {/* )} */}
+      ) : (
+        <>
+          <h1>Working</h1>
+          <TodoListBox ref={scrollRef}>
+            {todos.filter((v) => v.isDone === false).length !== 0
+              ? todos
+                  .filter((v) => v.isDone === false)
+                  .map((v) => <Item key={v.id} todo={v} />)
+              : "추가된 할일이 없습니다."}
+          </TodoListBox>
+          <h1>Done</h1>
+          <TodoListBox>
+            {todos.filter((v) => v.isDone === true).length !== 0
+              ? todos
+                  .filter((v) => v.isDone === true)
+                  .map((v) => <Item key={v.id} todo={v} />)
+              : "완료된 일이 없습니다."}
+          </TodoListBox>
+        </>
+      )}
     </Wrapper>
   );
 }


### PR DESCRIPTION
# 조건부 랜더링에서 `ref` 사용하도록 수정

## 문제 상황
`todos`의 요소 존재여부에 따라 조건부 랜더링을 하자 `ref`의 `current` 속성이 `null`인 문제 발생.
`setScroll()` 함수에서 `ref`로 완료된 `todo` 목록의 DOM scroll 위치를 `todo`가 새로 추가되어도 가장 오른쪽에 위치하도록 조정하는 동작이 실행되지 못함.

## 해결 방안
`ref.current`가 `null`이 아닌 조건을 확인하여 `setScroll()`의 동작이 실행되도록 수정.
`setScroll()` 이 실행되는 시점을 `console.log()`로 확인하여, 처음 `todos`가 `reducer`로 불러오기 전, 불러온 후 두 번 호출되는 것을 확인함. 따라서, 처음 랜더링 시에는 `ref.current`가 조건부 랜더링에 따라 `null`이기 때문에 에러가 발생했음.

