### PR TITLE
modify todoList to disable modification on past days

### DIFF
--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -28,6 +28,7 @@ const BtnWrapper = styled.div`
 const Btn = styled.button`
   width: 40%;
   height: 30px;
+  display: ${(props) => (props.show ? "block" : "none")};
   background-color: ${(props) => props.bgColor};
   border: none;
   border-radius: 10px;
@@ -47,6 +48,7 @@ const DeleteBtn = styled.span`
   width: 30px;
   height: 30px;
   line-height: 30px;
+  display: ${(props) => (props.show ? "block" : "none")};
   text-align: center;
   background-color: red;
   color: white;
@@ -56,7 +58,7 @@ const DeleteBtn = styled.span`
   }
 `;
 
-function Item({ todo }) {
+function Item({ todo, isToday }) {
   const todos = useSelector((store) => store.todos.todos);
   const todosID = useSelector((store) => store.todos.todosID);
   const dispatch = useDispatch();
@@ -114,7 +116,9 @@ function Item({ todo }) {
   return (
     <ItemBox>
       <DeleteBtnWrapper>
-        <DeleteBtn onClick={handleDeleteTodo}>✖</DeleteBtn>
+        <DeleteBtn onClick={handleDeleteTodo} show={isToday}>
+          ✖
+        </DeleteBtn>
       </DeleteBtnWrapper>
       {isModify ? (
         <>
@@ -140,7 +144,7 @@ function Item({ todo }) {
         </>
       )}
       <BtnWrapper>
-        <Btn onClick={handleUpdateTodoContent} bgColor="gray">
+        <Btn onClick={handleUpdateTodoContent} show={isToday} bgColor="gray">
           {isModify
             ? title.length === 0 || content.length === 0
               ? "취소"
@@ -149,6 +153,7 @@ function Item({ todo }) {
         </Btn>
         <Btn
           onClick={handleUpdateTodoState}
+          show={isToday}
           bgColor={todo.isDone ? "tomato" : "cornflowerBlue"}
         >
           {todo.isDone ? "취소" : "완료"}

--- a/src/components/TodoInput.js
+++ b/src/components/TodoInput.js
@@ -29,7 +29,7 @@ const Btn = styled.button`
   background-color: cornflowerblue;
 `;
 
-function TodoInput() {
+function TodoInput({ isToday }) {
   const id = Date.now();
   const todos = useSelector((store) => store.todos.todos);
   const todosID = useSelector((store) => store.todos.todosID);
@@ -80,6 +80,7 @@ function TodoInput() {
           onChange={handleChangeTitle}
           type="text"
           placeholder="내용을 입력해주세요."
+          disabled={!isToday}
         />
         <Label>내용</Label>
         <Input
@@ -87,6 +88,7 @@ function TodoInput() {
           onChange={handleChangeContent}
           type="text"
           placeholder="내용을 입력해주세요."
+          disabled={!isToday}
         />
       </div>
       <Btn onClick={addTodo}>추가하기</Btn>

--- a/src/pages/TodoList.js
+++ b/src/pages/TodoList.js
@@ -69,6 +69,16 @@ function TodoList() {
     dispatch(__getTodos(id));
   }, [dispatch, id]);
 
+  const isToday = () => {
+    const today = new Date(Date.now());
+    const writtenDay = new Date(todosID);
+    return (
+      today.getFullYear() === writtenDay.getFullYear() &&
+      today.getMonth() === writtenDay.getMonth() &&
+      today.getDay() === writtenDay.getDay()
+    );
+  };
+
   const date = new Date(todosID);
   return (
     <Wrapper>
@@ -77,7 +87,7 @@ function TodoList() {
         <Logo>TODO 🎯</Logo>
       </Header>
       <Progressbar></Progressbar>
-      <TodoInput></TodoInput>
+      <TodoInput isToday={isToday()}></TodoInput>
       {isLoading ? (
         <InfoBox>데이터를 불러오는 중입니다.</InfoBox>
       ) : todos.length === 0 ? (
@@ -89,7 +99,7 @@ function TodoList() {
             {todos.filter((v) => v.isDone === false).length !== 0
               ? todos
                   .filter((v) => v.isDone === false)
-                  .map((v) => <Item key={v.id} todo={v} />)
+                  .map((v) => <Item key={v.id} todo={v} isToday={isToday()} />)
               : "추가된 할일이 없습니다."}
           </TodoListBox>
           <h1>Done</h1>
@@ -97,7 +107,7 @@ function TodoList() {
             {todos.filter((v) => v.isDone === true).length !== 0
               ? todos
                   .filter((v) => v.isDone === true)
-                  .map((v) => <Item key={v.id} todo={v} />)
+                  .map((v) => <Item key={v.id} todo={v} isToday={isToday()} />)
               : "완료된 일이 없습니다."}
           </TodoListBox>
         </>


### PR DESCRIPTION
# 당일 외 상세페이지 수정 불가하도록 수정
## 변경 전
날짜와 상관없이 `todoList` 페이지 이동시 수정 가능

## 변경 후
기획의도에 맞게 당일이 아닌 경우에는 `todoList` 페이지 내용 수정 기능 전부 `disabled` 혹은 `display: none`처리