### PR TITLE
modify progress bar css to not use left padding

### DIFF
--- a/src/components/Progressbar.js
+++ b/src/components/Progressbar.js
@@ -8,8 +8,7 @@ const Wrapper = styled.div`
 `;
 
 const ContentWrapper = styled.div`
-  width: 97%;
-  padding-left: 3%;
+  width: 100%;
   display: flex;
   flex-direction: row;
   justify-content: start;

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,6 @@
 body {
   margin: 0;
-  padding: 20px;
+  padding: 40px;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
     "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;


### PR DESCRIPTION
# `Progressbar`에서 `padding-left` 사용하지 않도록 수정
## 변경 전
`Progressbar`에 달리는 사람 icon을 사용하고 있어서 progress 상태가 0%일 때 달리는 사람 icon이 화면 왼쪽에서 잘려보이는 문제가 있음. 이를 해결하기 위해 `padding-left`를 사용했으나 progress 상태가 0%가 아닐때 `Progressbar`가 다른 element와 같은 선 상에 정렬되어 있지 않아 보여서 디자인적 오류가 있는 것처럼 보임.

## 변경 후
`Progressbar`가 다른 element와 정렬되어 보이도록 `padding-left` 속성은 없애면서, 
icon이 잘려보이지 않도록 전체 페이지의 `padding` 사이즈를 `20px` -> `40px`로 수정함.