### PR TITLE
modify todoInput to validate text length before add todo

### DIFF
--- a/src/components/TodoInput.js
+++ b/src/components/TodoInput.js
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import styled from "styled-components";
 import { __addTodo } from "../redux/modules/TodosSlice";
 
-const InputWrapper = styled.div`
+const Wrapper = styled.div`
   padding: 20px;
   background-color: #ccc;
   display: flex;
@@ -14,6 +14,10 @@ const InputWrapper = styled.div`
 
 const Label = styled.span`
   margin-right: 10px;
+`;
+
+const InputWrapper = styled.div`
+  float: left;
 `;
 
 const Input = styled.input`
@@ -42,10 +46,20 @@ function TodoInput({ isToday }) {
   const ref = useRef();
 
   const handleChangeTitle = ({ target: { value } }) => {
+    if (value.length > 15) {
+      alert("제목은 15자 이하로 작성해주세요");
+      return;
+    }
+
     setTodo({ ...todo, title: value });
   };
 
   const handleChangeContent = ({ target: { value } }) => {
+    if (value.length > 20) {
+      alert("내용은 20자 이하로 작성해주세요");
+      return;
+    }
+
     setTodo({ ...todo, content: value });
   };
 
@@ -71,28 +85,37 @@ function TodoInput({ isToday }) {
   };
 
   return (
-    <InputWrapper>
+    <Wrapper>
       <div>
-        <Label>제목</Label>
-        <Input
-          ref={ref}
-          value={todo.title}
-          onChange={handleChangeTitle}
-          type="text"
-          placeholder="내용을 입력해주세요."
-          disabled={!isToday}
-        />
-        <Label>내용</Label>
-        <Input
-          value={todo.content}
-          onChange={handleChangeContent}
-          type="text"
-          placeholder="내용을 입력해주세요."
-          disabled={!isToday}
-        />
+        <InputWrapper>
+          <Label>제목</Label>
+          <Input
+            ref={ref}
+            value={todo.title}
+            onChange={handleChangeTitle}
+            type="text"
+            placeholder="내용을 입력해주세요."
+            disabled={!isToday}
+          />
+        </InputWrapper>
+        <InputWrapper>
+          <Label>내용</Label>
+          <Input
+            value={todo.content}
+            onChange={handleChangeContent}
+            type="text"
+            placeholder="내용을 입력해주세요."
+            disabled={!isToday}
+          />
+        </InputWrapper>
       </div>
-      <Btn onClick={addTodo}>추가하기</Btn>
-    </InputWrapper>
+      <Btn
+        onClick={addTodo}
+        disabled={todo.title.length === 0 || todo.content.length === 0}
+      >
+        추가하기
+      </Btn>
+    </Wrapper>
   );
 }
 


### PR DESCRIPTION
# `todoInput` 입력 글자 길이 제한하도록 수정
## 변경 전
`todo.title`과 `todo.content` 내용 미입력시에도 버튼 클릭 가능.
(단, `todo.title`과 `todo.content`의 길이가 0인 경우, `내용을 입력해주세요` 알림창 표시.)
`todo.title`과 `todo.content` 내용 길이 제한이 없어 `Item`의 높이가 서로 달라지는 문제 발생.

## 변경 후
`todo.title`과 `todo.content` 내용 미입력시 버튼 `disabled`.
화면 디자인에 맞춰 `todo.title`은 최대 15자, `todo.content`는 최대 20자까지 입력 가능하도록 제한을 두어 초과 입력시 알림창을 띄워 제한 글자수를 안내하고, 추가적인 글자 입력을 막음.