### PR TITLE
fix showing wrong month and date

### DIFF
--- a/src/pages/TodoList.js
+++ b/src/pages/TodoList.js
@@ -75,7 +75,7 @@ function TodoList() {
     return (
       today.getFullYear() === writtenDay.getFullYear() &&
       today.getMonth() === writtenDay.getMonth() &&
-      today.getDay() === writtenDay.getDay()
+      today.getDate() === writtenDay.getDate()
     );
   };
 
@@ -83,7 +83,7 @@ function TodoList() {
   return (
     <Wrapper>
       <Header>
-        {`${date.getFullYear()}년 ${date.getMonth()}월 ${date.getDay()}일`}
+        {`${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`}
         <Logo>TODO 🎯</Logo>
       </Header>
       <Progressbar></Progressbar>


### PR DESCRIPTION
# `todoList` 에서 잘못된 월, 일 표시되는 부분 수정
## 문제 상황
테스트용 데이터인 `todos`의 `id` 값(`todos`가 작성된 일자의 unix timestamp 값)이 `1670676178140` 인데, unix timestamp converter를 사용하면 `2022년 12월 10일`로 나오지만, 화면에서는 `2022년 11월 6일`로 다르게 표시되는 문제 발생.

## 해결 방안
문제 상황에서 사용하던 javascript built-in 메소드에 대해 조사해본 결과, 아래와 같은 특징이 있었음.
* `Date.prototype.getMonth()` : 0부터 11까지의 숫자로 해당 Date의 월을 반환한다.
* `Date.prototype.getDay()`: 주단위의 일자를 반환한다. 즉, 해당 Date의 요일의 순번을 반환한다. (ex. 토요일 -> 6 반환)
따라서, 월은 `+1` 을하여 보여주도록 수정하고, 일은 `Date.prototype.getDate()`를 사용하도록 수정.

### 참고 문서
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getMonth
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getDay
