### PR TITLE
fix progress bar to use todos data from parent component

### DIFF
--- a/src/components/Progressbar.js
+++ b/src/components/Progressbar.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { useSelector } from "react-redux";
 import styled from "styled-components";
 
 const Wrapper = styled.div`
@@ -60,8 +59,7 @@ const StateIcon = styled.span`
   transition: font-size 1s;
 `;
 
-function Progressbar() {
-  const todos = useSelector((store) => store.todos.todos);
+function Progressbar({ todos }) {
   const donesCount = todos.filter((v) => v.isDone === true).length;
   const donesPercentage = (donesCount / todos.length) * 100;
   return (

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -159,7 +159,7 @@ function Home() {
               key={todos.id}
             >
               <DateSt>{year + "년" + month + "월" + day + "일"}</DateSt>
-              <Progressbar />
+              <Progressbar todos={todos.items} />
               <CommentCount>💬{commentcount}</CommentCount>
             </CardWrapper>
           );

--- a/src/pages/TodoList.js
+++ b/src/pages/TodoList.js
@@ -6,9 +6,8 @@ import { __getTodos } from "../redux/modules/TodosSlice";
 import Progressbar from "../components/Progressbar";
 import TodoInput from "../components/TodoInput";
 import Item from "../components/Item";
+import CommentList from "../components/comments/CommentList";
 import { useParams } from "react-router-dom";
-
-import CommentList from "../components/comments/CommentList"
 
 const Wrapper = styled.div`
   width: 100%;
@@ -88,7 +87,7 @@ function TodoList() {
         {`${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`}
         <Logo>TODO 🎯</Logo>
       </Header>
-      <Progressbar></Progressbar>
+      <Progressbar todos={todos}></Progressbar>
       <TodoInput isToday={isToday()}></TodoInput>
       {isLoading ? (
         <InfoBox>데이터를 불러오는 중입니다.</InfoBox>
@@ -112,7 +111,7 @@ function TodoList() {
                   .map((v) => <Item key={v.id} todo={v} isToday={isToday()} />)
               : "완료된 일이 없습니다."}
           </TodoListBox>
-          <CommentList date={id}/>
+          <CommentList date={id} />
         </>
       )}
     </Wrapper>


### PR DESCRIPTION
# `Progressbar`에서 사용하는`todos`를 props로 받도록 수정
## 변경 전
`Progressbar` 컴포넌트가 `store`의 상세페이지 `todos`를 직접 구독하는 형태로, 홈페이지에서 사용될 때 `todos` 데이터를 사용하지 못하는 문제 발생.

## 변경 후
`Progressbar` 컴포넌트가 `todos`를 props로 받아 사용하도록 수정.
`Home`, `TodoList` 페이지에서 사용하는 `todos`를 직접 넘겨주는 방식으로 사용.