### PR TITLE
fix todo to use todo data as default value of input

### DIFF
--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -63,20 +63,20 @@ function Item({ todo, isToday }) {
   const todosID = useSelector((store) => store.todos.todosID);
   const dispatch = useDispatch();
   const [isModify, setIsModify] = useState(false);
-  const [title, setTitle] = useState("");
-  const [content, setContent] = useState("");
+  const [title, setTitle] = useState(todo.title);
+  const [content, setContent] = useState(todo.content);
   const handleUpdateTodoContent = async () => {
     try {
       if (!isModify) {
         return;
       }
 
-      if (title.length === 0 || content.length === 0) {
+      if (title === todo.title && content === todo.content) {
         return;
       }
 
-      if (title === todo.title && content === todo.content) {
-        alert("변경된 내용이 없습니다.");
+      if (title.length === 0 || content.length === 0) {
+        alert("내용을 입력해주세요.");
         return;
       }
 
@@ -87,10 +87,10 @@ function Item({ todo, isToday }) {
           todo: { ...todo, title, content },
         })
       );
-    } finally {
-      setIsModify(!isModify);
       setTitle("");
       setContent("");
+    } finally {
+      setIsModify(!isModify);
     }
   };
   const handleChangeTitle = ({ target: { value } }) => {
@@ -146,7 +146,7 @@ function Item({ todo, isToday }) {
       <BtnWrapper>
         <Btn onClick={handleUpdateTodoContent} show={isToday} bgColor="gray">
           {isModify
-            ? title.length === 0 || content.length === 0
+            ? title === todo.title && content === todo.content
               ? "취소"
               : "수정완료"
             : "수정하기"}


### PR DESCRIPTION
# `todo` 내용 수정 시 기존 `todo` 값을 사용하도록 수정
## 변경 전
* `todo` 내용 수정 시 input의 value 값을 빈값으로 `setState` 함.
* placeholder 값으로 기존 `todo` 값 사용.
* 수정하고자 입력한 `todo`의 `title`, `content`가 길이가 0인 경우에 버튼에 `취소` 표시.
* `취소`, `수정 완료` 버튼 클릭 시, `todo` input value 값을 `setState("")`. 

## 변경 후
* `todo` 내용 수정 시 input의 value값을 기존 `todo` 값 사용.
* 수정하고자 입력한 `todo`의 `title`, `content` 가 기존의 `todo` 값과 모두 동일한 경우 버튼에 `취소` 표시.
* `취소`, `수정 완료` 버튼 클릭 시, db에 수정사항이 반영 완료된 경우에만 `todo` input value 값을 `setState("")`. 