### PR TITLE
fix home page to add todos with empty items array

### DIFF
--- a/src/components/Progressbar.js
+++ b/src/components/Progressbar.js
@@ -60,9 +60,8 @@ const StateIcon = styled.span`
   transition: font-size 1s;
 `;
 
-function Progressbar() {
-  const todos = useSelector((store) => store.todos.todos);
-  const donesCount = todos.filter((v) => v.isDone === true).length;
+function Progressbar({ todos }) {
+  const donesCount = todos?.filter((v) => v.isDone === true).length;
   const donesPercentage = (donesCount / todos.length) * 100;
   return (
     <Wrapper>

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -69,14 +69,11 @@ const ButtonSt = styled.button`
 function Home() {
   const navigate = useNavigate();
   const id = Date.now();
-  const date = new Date();
-  let day = date.getUTCDate();
 
   const [comments, setComments] = useState([]);
   const [allTodos, setAllTodos] = useState([]);
   const [todos, setTodos] = useState({
     id: 0,
-    day: 0,
     items: [],
   });
 
@@ -125,9 +122,8 @@ function Home() {
       await axios.post(`http://localhost:3001/todos`, {
         ...todos,
         id,
-        day,
       });
-      setAllTodos([...allTodos, { todos, id }]);
+      setAllTodos([...allTodos, { ...todos, id }]);
     } catch (e) {
       alert(e);
     }
@@ -159,7 +155,7 @@ function Home() {
               key={todos.id}
             >
               <DateSt>{year + "년" + month + "월" + day + "일"}</DateSt>
-              <Progressbar />
+              <Progressbar todos={todos.items} />
               <CommentCount>💬{commentcount}</CommentCount>
             </CardWrapper>
           );


### PR DESCRIPTION
# `Home` 페이지에서 `addTodos` 요청 시, 초기 `items` 값을 누락하지 않도록 수정
## 문제 사항
`Home` 페이지에서 새로운 `todos` 추가 시, `Progressbar`에서 받는 `todos(=items)` 값이 `undefined` 여서 `filter` 메소드가 호출되지 못하는 문제 발생

## 해결 방안
`Home` 페이지의 `addTodos` 함수에 `post` 요청하는 부분에서 보내는 `todos`가 전개 연산자를 사용하지 않아서, `todos` 객체가 `id` 값과 각각의 필드로 전송되는 문제가 있었음.
```
await axios.post(`http://localhost:3001/todos`, { todos, id });
``` 
`todos`를 전개 연산자로 넣어서, 기존의 `todos` 형태로 전송되도록 수정.
```
await axios.post(`http://localhost:3001/todos`, { ...todos, id });
``` 