### PR TITLE
modify todo to show different button on todo modify state

### DIFF
--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -63,20 +63,20 @@ function Item({ todo, isToday }) {
   const todosID = useSelector((store) => store.todos.todosID);
   const dispatch = useDispatch();
   const [isModify, setIsModify] = useState(false);
-  const [title, setTitle] = useState("");
-  const [content, setContent] = useState("");
+  const [title, setTitle] = useState(todo.title);
+  const [content, setContent] = useState(todo.content);
   const handleUpdateTodoContent = async () => {
     try {
       if (!isModify) {
         return;
       }
 
-      if (title.length === 0 || content.length === 0) {
+      if (title === todo.title && content === todo.content) {
         return;
       }
 
-      if (title === todo.title && content === todo.content) {
-        alert("변경된 내용이 없습니다.");
+      if (title.length === 0 || content.length === 0) {
+        alert("내용을 입력해주세요.");
         return;
       }
 
@@ -87,10 +87,10 @@ function Item({ todo, isToday }) {
           todo: { ...todo, title, content },
         })
       );
-    } finally {
-      setIsModify(!isModify);
       setTitle("");
       setContent("");
+    } finally {
+      setIsModify(!isModify);
     }
   };
   const handleChangeTitle = ({ target: { value } }) => {
@@ -146,7 +146,7 @@ function Item({ todo, isToday }) {
       <BtnWrapper>
         <Btn onClick={handleUpdateTodoContent} show={isToday} bgColor="gray">
           {isModify
-            ? title.length === 0 || content.length === 0
+            ? title === todo.title && content === todo.content
               ? "취소"
               : "수정완료"
             : "수정하기"}

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -65,12 +65,14 @@ function Item({ todo, isToday }) {
   const [isModify, setIsModify] = useState(false);
   const [title, setTitle] = useState(todo.title);
   const [content, setContent] = useState(todo.content);
+  const handleModifyState = () => {
+    setIsModify(!isModify);
+    setTitle(todo.title);
+    setContent(todo.content);
+  };
+
   const handleUpdateTodoContent = async () => {
     try {
-      if (!isModify) {
-        return;
-      }
-
       if (title === todo.title && content === todo.content) {
         return;
       }
@@ -87,12 +89,11 @@ function Item({ todo, isToday }) {
           todo: { ...todo, title, content },
         })
       );
-      setTitle("");
-      setContent("");
     } finally {
       setIsModify(!isModify);
     }
   };
+
   const handleChangeTitle = ({ target: { value } }) => {
     setTitle(value);
   };
@@ -144,20 +145,34 @@ function Item({ todo, isToday }) {
         </>
       )}
       <BtnWrapper>
-        <Btn onClick={handleUpdateTodoContent} show={isToday} bgColor="gray">
-          {isModify
-            ? title === todo.title && content === todo.content
-              ? "취소"
-              : "수정완료"
-            : "수정하기"}
-        </Btn>
-        <Btn
-          onClick={handleUpdateTodoState}
-          show={isToday}
-          bgColor={todo.isDone ? "tomato" : "cornflowerBlue"}
-        >
-          {todo.isDone ? "취소" : "완료"}
-        </Btn>
+        {isModify ? (
+          <>
+            <Btn
+              onClick={handleUpdateTodoContent}
+              show={isToday}
+              bgColor="gray"
+              disabled={title === todo.title && content === todo.content}
+            >
+              수정완료
+            </Btn>
+            <Btn onClick={handleModifyState} show={isToday} bgColor="tomato">
+              수정취소
+            </Btn>
+          </>
+        ) : (
+          <>
+            <Btn onClick={handleModifyState} show={isToday} bgColor="gray">
+              수정하기
+            </Btn>
+            <Btn
+              onClick={handleUpdateTodoState}
+              show={isToday}
+              bgColor={todo.isDone ? "tomato" : "cornflowerBlue"}
+            >
+              {todo.isDone ? "취소" : "완료"}
+            </Btn>
+          </>
+        )}
       </BtnWrapper>
     </ItemBox>
   );


### PR DESCRIPTION
# `todo` 수정 시, 버튼 수정
## 변경 전
수정 시, 내용 변경이 있는 경우, `수정 완료` 버튼과 todo 상태 변경 버튼을 보여줌.
내용 변경이 없는 경우, `취소(=수정 취소)` 버튼과 todo 상태 변경 버튼을 보여줌.
`취소(=수정 취소)` 버튼이 todo 상태를 `isDone = false`로 바꿔주는 `취소` 버튼과 중복됨.
내용 변경을 한 이후에도 수정 취소를 하고 싶을 수 있는데, 수정 취소가 불가함.

## 변경 후
수정 시, `수정 완료` 버튼과 `수정 취소` 버튼을 보여줌.
`수정 완료` 버튼은 내용 변경이 없는 경우 `disabled` 되고, 변경이 있는 경우 클릭이 가능.
`수정 취소` 버튼 클릭 시, `todo` 수정 상태를 업데이트 하고, input의 value를 다시 `todo` 기존 값으로 초기화.