### PR TITLE
modify todo input style on todo modify state

### DIFF
--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -5,20 +5,47 @@ import { __deleteTodo, __updateTodo } from "../redux/modules/TodosSlice";
 
 const ItemBox = styled.div`
   width: 16%;
-  padding: 1%;
+  height: 180px;
+  padding: 20px 1%;
   float: left;
   flex: 0 0 auto;
   border: 3px solid cornflowerblue;
   border-radius: 20px;
 `;
 
+const ItemContentWrapper = styled.div`
+  position: relative;
+  width: 100%;
+  height: 150px;
+`;
+
 const ItemTitle = styled.h2`
+  margin: 0;
+  padding-bottom: 10px;
   font-weight: 800;
 `;
 
+const ItemInputWrapper = styled.div`
+  padding: 10px 0;
+`;
+
+const Label = styled.span`
+  width: 5%;
+  font-size: 16px;
+  font-weight: 600;
+`;
+
+const ItemInput = styled.input`
+  width: 85%;
+  height: 20px;
+  float: right;
+`;
+
 const BtnWrapper = styled.div`
+  position: absolute;
+  bottom: 0px;
+  left: 0px;
   width: 100%;
-  padding-top: 20px;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -121,59 +148,65 @@ function Item({ todo, isToday }) {
           ✖
         </DeleteBtn>
       </DeleteBtnWrapper>
-      {isModify ? (
-        <>
-          <div>제목</div>
-          <input
-            value={title}
-            onChange={handleChangeTitle}
-            type="text"
-            placeholder={todo.title}
-          />
-          <div>내용</div>
-          <input
-            value={content}
-            onChange={handleChangeContent}
-            type="text"
-            placeholder={todo.content}
-          />
-        </>
-      ) : (
-        <>
-          <ItemTitle>{todo.title}</ItemTitle>
-          {todo.content}
-        </>
-      )}
-      <BtnWrapper>
+      <ItemContentWrapper>
         {isModify ? (
-          <>
-            <Btn
-              onClick={handleUpdateTodoContent}
-              show={isToday}
-              bgColor="gray"
-              disabled={title === todo.title && content === todo.content}
-            >
-              수정완료
-            </Btn>
-            <Btn onClick={handleModifyState} show={isToday} bgColor="tomato">
-              수정취소
-            </Btn>
-          </>
+          <div>
+            <ItemInputWrapper>
+              <Label>제목</Label>
+              <ItemInput
+                value={title}
+                onChange={handleChangeTitle}
+                type="text"
+                placeholder={todo.title}
+              />
+            </ItemInputWrapper>
+            <ItemInputWrapper>
+              <Label>내용</Label>
+              <ItemInput
+                value={content}
+                onChange={handleChangeContent}
+                type="text"
+                placeholder={todo.content}
+              />
+            </ItemInputWrapper>
+          </div>
         ) : (
-          <>
-            <Btn onClick={handleModifyState} show={isToday} bgColor="gray">
-              수정하기
-            </Btn>
-            <Btn
-              onClick={handleUpdateTodoState}
-              show={isToday}
-              bgColor={todo.isDone ? "tomato" : "cornflowerBlue"}
-            >
-              {todo.isDone ? "취소" : "완료"}
-            </Btn>
-          </>
+          <div>
+            <ItemTitle>{todo.title}</ItemTitle>
+            {todo.content}
+          </div>
         )}
-      </BtnWrapper>
+        <BtnWrapper>
+          {isModify ? (
+            <>
+              <Btn
+                onClick={handleUpdateTodoContent}
+                show={isToday}
+                bgColor="gray"
+                disabled={title === todo.title && content === todo.content}
+              >
+                수정완료
+              </Btn>
+              <Btn onClick={handleModifyState} show={isToday} bgColor="tomato">
+                수정취소
+              </Btn>
+            </>
+          ) : (
+            <>
+              <Btn onClick={handleModifyState} show={isToday} bgColor="gray">
+                수정하기
+              </Btn>
+              <Btn
+                onClick={handleUpdateTodoState}
+                show={isToday}
+                bgColor={todo.isDone ? "tomato" : "cornflowerBlue"}
+              >
+                {todo.isDone ? "취소" : "완료"}
+              </Btn>
+            </>
+          )}
+        </BtnWrapper>
+      </ItemContentWrapper>
     </ItemBox>
   );
 }


### PR DESCRIPTION
# `todo` 수정 시 디자인 개선
## 변경 전
`todo(=Item)`의 `height`가 고정값이 아니라 자식요소의 높이에 따라 변경되므로 브라우저 환경에 따라 `todo`의 내용에 따라 높이가 다르게 보임.
수정 시에도 `input`의 높이가 본문 컨텐츠의 높이보다 작아지면서 `todo`의 높이가 달라짐.

## 변경 후
`todo`의 `height`를 고정값으로 디자인하고, 하단 버튼의 위치를 고정.
수정 상태일 때와 아닐 때의 `todo`의 높이가 달라지지 않음.
`input`의 가로 폭을 `todo`의 폭에 맞게 반응형으로 수정.
수정 시에 긴 문장을 작성할 때 커서를 움직여 보이지 않는 내용을 봐야하는 불편함을 줄임.
