### PR TITLE
modify todoList to add padding between dones and comment

### DIFF
--- a/src/pages/TodoList.js
+++ b/src/pages/TodoList.js
@@ -48,6 +48,10 @@ const TodoListBox = styled.div`
   }
 `;
 
+const CommentListWrapper = styled.div`
+  padding-top: 20px;
+`;
+
 function TodoList() {
   const { id } = useParams();
   const isLoading = useSelector((store) => store.todos.isLoading);
@@ -111,7 +115,9 @@ function TodoList() {
                   .map((v) => <Item key={v.id} todo={v} isToday={isToday()} />)
               : "완료된 일이 없습니다."}
           </TodoListBox>
-          <CommentList todosId={id} />
+          <CommentListWrapper>
+            <CommentList todosId={id} />
+          </CommentListWrapper>
         </>
       )}
     </Wrapper>


### PR DESCRIPTION
# `todoList` 페이지 디자인 수정
## 변경 전
완료한 일, 댓글 component 사이에 공간이 없음.
가로 스크롤이 생성되면 댓글 component가 바로 아래에 붙어있는 형태.

## 변경 후
완료한 일, 댓글 component 사이에 `padding: 20px` 추가