### PR TITLE
modify progressbar to show different design by parent component setting

### DIFF
--- a/src/components/Progressbar.js
+++ b/src/components/Progressbar.js
@@ -38,7 +38,7 @@ const ProgressBar = styled.div`
 
 const ProgressBarIcon = styled.span`
   position: absolute;
-  right: -15px;
+  right: ${(props) => props.position};
   top: -15px;
   font-size: 40px;
   transform: rotateY(180deg);
@@ -55,11 +55,12 @@ const StateWrapper = styled.div`
 `;
 
 const StateIcon = styled.span`
+  display: ${(props) => props.display};
   font-size: ${(props) => props.fontSize};
   transition: font-size 1s;
 `;
 
-function Progressbar({ todos }) {
+function Progressbar({ todos, isSmallSize }) {
   const donesCount = todos?.filter((v) => v.isDone === true).length;
   const donesPercentage = (donesCount / todos.length) * 100;
   return (
@@ -68,11 +69,16 @@ function Progressbar({ todos }) {
       <ContentWrapper>
         <ProgressBarWrapper>
           <ProgressBar width={`${donesPercentage}%`}>
-            <ProgressBarIcon>🏃</ProgressBarIcon>
+            <ProgressBarIcon
+              position={donesPercentage === 0 ? "-40px" : "-15px"}
+            >
+              🏃
+            </ProgressBarIcon>
           </ProgressBar>
         </ProgressBarWrapper>
         <StateWrapper>
           <StateIcon
+            display={isSmallSize ? "none" : ""}
             fontSize={
               donesPercentage > 50
                 ? donesPercentage === 100

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -154,7 +154,7 @@ function Home() {
               key={todos.id}
             >
               <DateSt>{year + "년" + month + "월" + day + "일"}</DateSt>
-              <Progressbar todos={todos.items} />
+              <Progressbar todos={todos.items} isSmallSize={true} />
               <CommentCount>💬{commentcount}</CommentCount>
             </CardWrapper>
           );

--- a/src/pages/TodoList.js
+++ b/src/pages/TodoList.js
@@ -91,7 +91,7 @@ function TodoList() {
         {`${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`}
         <Logo>TODO 🎯</Logo>
       </Header>
-      <Progressbar todos={todos}></Progressbar>
+      <Progressbar todos={todos} isSmallSize={false}></Progressbar>
       <TodoInput isToday={isToday()}></TodoInput>
       {isLoading ? (
         <InfoBox>데이터를 불러오는 중입니다.</InfoBox>


### PR DESCRIPTION
# `Progressbar` 컴포넌트를 반응형으로 수정
## 변경 전
* `Home`, `TodoList` 페이지에서 모두 `Progressbar`를 사용하지만 `TodoList`를 기준으로 디자인 되어 있기 때문에 `Home` 에서 `Progressbar`의 요소가 카드 밖을 벗어남.
* `Progressbar`가 진행률이 0% 일 때, 달리는 사람 icon이 바깥으로 벗어나 디자인 오류가 있는 것으로 보임.

## 변경 후
* `Progressbar`가 boolean 값인 `isSmallSize`를 props로 받도록 수정하여 동적으로 디자인 요소 제어.
*  진행률이 0% 일 때, 동적으로 달리는 사람 icon 위치를 변경하도록 수정.