### PR TITLE
modify reducer to not use pending action on add, update, delete todo

### DIFF
--- a/src/pages/TodoList.js
+++ b/src/pages/TodoList.js
@@ -61,9 +61,8 @@ function TodoList() {
   const scrollRef = useRef(null);
 
   const setScroll = () => {
-    if (scrollRef.current !== null) {
-      scrollRef.current.scrollLeft += 300 * (todos.length - 1);
-    }
+    if (!scrollRef?.current) return;
+    scrollRef.current.scrollLeft += 300 * (todos.length - 1);
   };
 
   useEffect(() => {
@@ -101,17 +100,17 @@ function TodoList() {
         <>
           <h1>Working</h1>
           <TodoListBox ref={scrollRef}>
-            {todos.filter((v) => v.isDone === false).length !== 0
+            {todos.filter((v) => !v.isDone).length !== 0
               ? todos
-                  .filter((v) => v.isDone === false)
+                  .filter((v) => !v.isDone)
                   .map((v) => <Item key={v.id} todo={v} isToday={isToday()} />)
               : "추가된 할일이 없습니다."}
           </TodoListBox>
           <h1>Done</h1>
           <TodoListBox>
-            {todos.filter((v) => v.isDone === true).length !== 0
+            {todos.filter((v) => v.isDone).length !== 0
               ? todos
-                  .filter((v) => v.isDone === true)
+                  .filter((v) => v.isDone)
                   .map((v) => <Item key={v.id} todo={v} isToday={isToday()} />)
               : "완료된 일이 없습니다."}
           </TodoListBox>

--- a/src/redux/modules/TodosSlice.js
+++ b/src/redux/modules/TodosSlice.js
@@ -80,22 +80,13 @@ const todosSlice = createSlice({
       state.todosID = action.payload.id;
       state.todos = action.payload.items;
     });
-    builder.addCase(__addTodo.pending, (state) => {
-      state.isLoading = true;
-    });
     builder.addCase(__addTodo.fulfilled, (state, action) => {
       state.isLoading = false;
       state.todos = [...state.todos, action.payload];
     });
-    builder.addCase(__updateTodo.pending, (state) => {
-      state.isLoading = true;
-    });
     builder.addCase(__updateTodo.fulfilled, (state, action) => {
       state.isLoading = false;
       state.todos = action.payload;
-    });
-    builder.addCase(__deleteTodo.pending, (state) => {
-      state.isLoading = true;
     });
     builder.addCase(__deleteTodo.fulfilled, (state, action) => {
       state.isLoading = false;


### PR DESCRIPTION
# `todo` add, update, delete 시에 `isLoading` 전역 상태를 update 하지 않도록 수정
## 변경 전
`todo`를 추가, 수정, 삭제 할 때마다 `isLoading` 상태의 컴포넌트를 보여줌.
리랜더링 시마다 화면이 깜빡여 보임.

## 변경 후
`todo`를 추가, 수정, 삭제 할 때에는 `isLoading` 상태가 보이지 않고 자연스러운 컴포넌트 변경이 일어남.