### PR TITLE
modify todoList to use editHistory for setting scroll

### DIFF
--- a/db.json
+++ b/db.json
@@ -7,7 +7,8 @@
           "id": 1670659778436,
           "title": "청소",
           "content": "빨래",
-          "isDone": false
+          "isDone": false,
+          "editHistory": 0
         }
       ]
     }

--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -133,7 +133,7 @@ function Item({ todo, isToday }) {
       __updateTodo({
         todosID,
         todos,
-        todo: { ...todo, isDone: !todo.isDone },
+        todo: { ...todo, isDone: !todo.isDone, editHistory: Date.now() },
       })
     );
   };

--- a/src/components/TodoInput.js
+++ b/src/components/TodoInput.js
@@ -42,6 +42,7 @@ function TodoInput({ isToday }) {
     title: "",
     content: "",
     isDone: false,
+    editHistory: 0,
   });
   const ref = useRef();
 

--- a/src/pages/TodoList.js
+++ b/src/pages/TodoList.js
@@ -55,19 +55,55 @@ const CommentListWrapper = styled.div`
 function TodoList() {
   const { id } = useParams();
   const isLoading = useSelector((store) => store.todos.isLoading);
-  const todos = useSelector((store) => store.todos.todos);
   const todosID = useSelector((store) => store.todos.todosID);
-  const dispatch = useDispatch();
-  const scrollRef = useRef(null);
+  const todos = useSelector((store) => store.todos.todos);
+  const workings = useSelector((store) =>
+    store.todos.todos
+      .filter((v) => !v.isDone)
+      .sort((a, b) => {
+        if (a.editHistory > b.editHistory) return 1;
+        if (a.editHistory < b.editHistory) return -1;
 
-  const setScroll = () => {
-    if (!scrollRef?.current) return;
-    scrollRef.current.scrollLeft += 300 * (todos.length - 1);
+        if (a.id > b.id) return 1;
+        if (a.id < b.id) return -1;
+
+        return 0;
+      })
+  );
+  const dones = useSelector((store) =>
+    store.todos.todos
+      .filter((v) => v.isDone)
+      .sort((a, b) => {
+        if (a.editHistory > b.editHistory) return 1;
+        if (a.editHistory < b.editHistory) return -1;
+
+        if (a.id > b.id) return 1;
+        if (a.id < b.id) return -1;
+
+        return 0;
+      })
+  );
+  const dispatch = useDispatch();
+  const workingScrollRef = useRef(null);
+  const doneScrollRef = useRef(null);
+
+  const setWorkingsScroll = () => {
+    if (!workingScrollRef?.current) return;
+    workingScrollRef.current.scrollLeft += 300 * (workings.length - 1);
+  };
+
+  const setDonesScroll = () => {
+    if (!doneScrollRef?.current) return;
+    doneScrollRef.current.scrollLeft += 300 * (dones.length - 1);
   };
 
   useEffect(() => {
-    setScroll();
-  }, [todos]);
+    setWorkingsScroll();
+  }, [workings[workings.length - 1]]);
+
+  useEffect(() => {
+    setDonesScroll();
+  }, [dones[dones.length - 1]]);
 
   useEffect(() => {
     dispatch(__getTodos(id));
@@ -99,19 +135,19 @@ function TodoList() {
       ) : (
         <>
           <h1>Working</h1>
-          <TodoListBox ref={scrollRef}>
-            {todos.filter((v) => !v.isDone).length !== 0
-              ? todos
-                  .filter((v) => !v.isDone)
-                  .map((v) => <Item key={v.id} todo={v} isToday={isToday()} />)
+          <TodoListBox ref={workingScrollRef}>
+            {workings.length !== 0
+              ? workings.map((v) => (
+                  <Item key={v.id} todo={v} isToday={isToday()} />
+                ))
               : "추가된 할일이 없습니다."}
           </TodoListBox>
           <h1>Done</h1>
-          <TodoListBox>
-            {todos.filter((v) => v.isDone).length !== 0
-              ? todos
-                  .filter((v) => v.isDone)
-                  .map((v) => <Item key={v.id} todo={v} isToday={isToday()} />)
+          <TodoListBox ref={doneScrollRef}>
+            {dones.length !== 0
+              ? dones.map((v) => (
+                  <Item key={v.id} todo={v} isToday={isToday()} />
+                ))
               : "완료된 일이 없습니다."}
           </TodoListBox>
           <CommentListWrapper>


### PR DESCRIPTION
# `todoList`의 목록별 `setScroll` 기능 수정
##  변경 전
* `isDone = false`인 `todos`가 전역 state `todos`가 수정될 때마다 스크롤을 가장 오른쪽 끝에 고정시킴.
* `isDone = false` 인 `todos`와 `isDone = true` 인 `todos`가 취소, 완료 시점과 상관 없이 초기에 추가된 시점의 순서대로만 정렬됨.

## 변경 후
* `isDone = false` 인 `todos` (=`workings`)에 새로운 요소가 추가되었을 때, `isDone = true`인 `todos` (=`dones`)에 새로운 요소가 추가되었을 때에만 각각의 스크롤을 가장 오른쪽 끝에 고정시킴.
* `workings`, `dones`의 요소가 상태가 변경된 시점인 `editHistory`를 기준으로 정렬됨