### PR TITLE
fix todo to limit title, content length on modification

### DIFF
--- a/src/components/Item.js
+++ b/src/components/Item.js
@@ -122,9 +122,19 @@ function Item({ todo, isToday }) {
   };
 
   const handleChangeTitle = ({ target: { value } }) => {
+    if (value.length > 15) {
+      alert("제목은 15자 이하로 작성해주세요");
+      return;
+    }
+
     setTitle(value);
   };
   const handleChangeContent = ({ target: { value } }) => {
+    if (value.length > 20) {
+      alert("내용은 20자 이하로 작성해주세요");
+      return;
+    }
+
     setContent(value);
   };
 


### PR DESCRIPTION
# `todo` 수정 시, 내용 길이 제한하도록 수정
## 변경 전
`todo` 수정 시, 처음 추가할 때와 다르게 제목, 내용 길이 제한이 없음.

## 변경 후
`todo` 수정 시, 처음 추가할 때와 동일하게 제목은 15자, 내용은 20자 길이 제한이 있음.