### PR TITLE
modify todos initial state to show todo basic structure

### DIFF
--- a/src/redux/modules/TodosSlice.js
+++ b/src/redux/modules/TodosSlice.js
@@ -1,12 +1,6 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import client from "../../api/client";
 
-const initialState = {
-  todos: [],
-  todosID: 0,
-  isLoading: false,
-};
-
 export const __getTodos = createAsyncThunk(
   "getTodos",
   async (payload, thunkAPI) => {
@@ -65,6 +59,20 @@ export const __deleteTodo = createAsyncThunk(
     }
   }
 );
+
+const initialState = {
+  todos: [
+    {
+      id: 0,
+      title: "",
+      content: "",
+      isDone: false,
+      editHistory: 0,
+    },
+  ],
+  todosID: 0,
+  isLoading: false,
+};
 
 const todosSlice = createSlice({
   name: "todos",


### PR DESCRIPTION
# `todo` 데이터 기본 구조가 보이도록 `todos` initial state 수정
## 변경 전
`db.json` 파일을 통해 `todo`의 기본 구조를 확인해야 함.

## 변경 후
`todos` 데이터를 관리하는 `todosSlice` 모듈에서 `todos`가 가지고 있는 `todo`의 기본 구조 확인 가능.
`commentsSlice` 와 통일성 유지. 